### PR TITLE
it's called OS X not OSX

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,7 @@
 		<ul id="links">
 			<li class="download dl-mac">
 				<a data-i18n="download.text" data-os="Mac" data-file="Popcorn-Time-0.3.2-Mac.dmg" class="btn-main icon-mac">Download Beta 3.2</a><br />
-				<small data-i18n="download.mac">For Mac OSX 10.7 and above&nbsp;&nbsp;|&nbsp;&nbsp;<a data-scroll href="#get-app">Other platforms</a></small>
+				<small data-i18n="download.mac">For Mac OS X 10.7 and above&nbsp;&nbsp;|&nbsp;&nbsp;<a data-scroll href="#get-app">Other platforms</a></small>
 			</li>
 			<li class="download dl-win">
 				<a data-i18n="download.text" data-os="Windows" data-file="Popcorn-Time-0.3.2-Win.zip" class="btn-main icon-win">Download Beta 3.2</a><br />
@@ -95,7 +95,7 @@
 				<h2>Best of all... it's free!</h2>
 				<div class="dl-mac">
 					<a data-i18n="download.text" data-os="Mac" data-file="Popcorn-Time-0.3.2-Mac.dmg" class="btn-main icon-mac">Download Beta 3.2</a>
-					<small data-i18n="download.mac">For Mac OSX 10.7 and above&nbsp;&nbsp;|&nbsp;&nbsp;<a data-scroll href="#get-app">Other platforms</a></small>
+					<small data-i18n="download.mac">For Mac OS X 10.7 and above&nbsp;&nbsp;|&nbsp;&nbsp;<a data-scroll href="#get-app">Other platforms</a></small>
 				</div>
 				<div class="dl-win">
 					<a data-i18n="download.text" data-os="Windows" data-file="Popcorn-Time-0.3.2-Win.zip" class="btn-main icon-win">Download Beta 3.2</a>
@@ -132,7 +132,7 @@
 			<ul id="platforms" class="platforms">
 				<li class="mac icon-laptop">
 					<a data-i18n="download.text" data-os="Mac" data-file="Popcorn-Time-0.3.2-Mac.dmg" class="btn-main icon-mac">Download Beta 3.2</a>
-					<small data-i18n="download.mac">For Mac OSX 10.7 and above</small>
+					<small data-i18n="download.mac">For Mac OS X 10.7 and above</small>
 				</li>
 				<li class="win icon-screen">
 					<a data-i18n="download.text" data-os="Windows" data-file="Popcorn-Time-0.3.2-Win.zip" class="btn-main icon-win">Download Beta 3.2</a>


### PR DESCRIPTION
See https://www.apple.com/osx/ and https://en.wikipedia.org/wiki/OS_X.

And technically we don't have to say "Mac OS X", just "OS X", but it's fine if you want to call it like that.

Thank you.
