### PR TITLE
Checksumming

### DIFF
--- a/src/faq.html
+++ b/src/faq.html
@@ -46,6 +46,18 @@
 				<h2>What happens to the movies after I'm done?</h2>
 				<p>Your movies will stay buried in a secret folder somewhere in your drive until you restart your computer. Then it will be gone for good.</p>
 			</article>
+            <article id="Download Integrity">
+				<h2>How can I be sure the download is unmodified and safe?</h2>
+				<p>For your additional security we offer optional checksumming of our downloads by listing SHA1 and SHA256 checksums underneath the download links. If the checksum you produce matches the checksum on our site underneath your respective download then you have a safe, unmodified download from our server. If you want to know more about how checksums work <a href="https://en.wikipedia.org/wiki/Checksum">this</a> Wikipedia article explains their function.</p>
+			</article>
+            
+            </article>
+            <article id="How do I checksum?">
+				<h2>How can I verify the checksums?</h2>
+                <li>On Windows we recommend using <a href="http://www.bitser.org/checksum-calculator-windows-7-freeware.shtml">Bitser</a>, an easy-to-use tool that can verify both SHA1 and SHA256.</li>
+                <li>On OS X you can natively check SHA1 checksums by opening up your Terminal application and executing <em>"SHASUM"</em> and then the location of the download you wish to check, such as <em> "SHASUM ~/Downloads/Popcorn-Time-0.3.2-Mac.dmg"</em>. If you prefer to check the SHA256 you can download the excellent <a href="https://github.com/jessek/hashdeep">Hashdeep</a> package through <a href="http://brew.sh/">Homebrew</a> with <em>"brew install hashdeep"</em>.</li>
+                <li>On Linux it is usually a case of simply opening your Terminal application and executing <em>"SHA1SUM"</em> or <em>"SHA256SUM"</em> followed by your download location, such as <em>"SHA256SUM /home/username/downloads/Popcorn-Time-0.3.2-Linux-32.tar.gz"</em>.</li>
+			</article>
 
 			<article id="update">
 				<h2>Will there be a new version?</h2>

--- a/src/index.html
+++ b/src/index.html
@@ -132,19 +132,27 @@
 			<ul id="platforms" class="platforms">
 				<li class="mac icon-laptop">
 					<a data-i18n="download.text" data-os="Mac" data-file="Popcorn-Time-0.3.2-Mac.dmg" class="btn-main icon-mac">Download Beta 3.2</a>
-					<small data-i18n="download.mac">For Mac OSX 10.7 and above</small>
+                    <small data-i18n="download.mac">For Mac OSX 10.7 and above.</small>               
+                <ul style="font-size: 11px;"><em>SHA1: 8c607cb8d2fb13ec25e329a3fc432ce47643c7e1</em></ul>
+<ul style="font-size: 11px;"><em>SHA256: abeea0d1de945311d1552764a9842142c8d317ba7ea0b01c15d45f4bdd815206</em></ul>
 				</li>
 				<li class="win icon-screen">
 					<a data-i18n="download.text" data-os="Windows" data-file="Popcorn-Time-0.3.2-Win.zip" class="btn-main icon-win">Download Beta 3.2</a>
 					<small data-i18n="download.windows">For Windows 7 and above</small>
+                    <ul style="font-size: 11px;"><em>SHA1: 11318c2e28f1c9540d455cc275d4e10179c57629</em></ul>
+<ul style="font-size: 11px;"><em>SHA256: ea2dba043880b85c65a3105d49b1849c3d048d457ac20da290e85f1c1e6bb7bd</em></ul>
 				</li>
 				<li class="lin-32 icon-window">
 					<a data-i18n="download.text" data-os="Linux 32" data-file="Popcorn-Time-0.3.2-Linux-32.tar.gz" class="btn-main icon-linux">Download Beta 3.2</a>
 					<small data-i18n="download.linux32">For 32-bit Linux</small>
+                    <ul style="font-size: 11px;"><em>SHA1: 4538ce1083d0569df329e155ef7e009ffb85f7e1</em></ul>
+<ul style="font-size: 11px;"><em>SHA256: f253604aaadc36887784917a2569cdcc8c7a5b475360b1ae8bf4f080cc4db362</em></ul>
 				</li>
 				<li class="lin-64 icon-window">
 					<a data-i18n="download.text" data-os="Linux 64" data-file="Popcorn-Time-0.3.2-Linux-64.tar.gz" class="btn-main icon-linux">Download Beta 3.2</a>
 					<small data-i18n="download.linux64">For 64-bit Linux</small>
+                     <ul style="font-size: 11px;"><em>SHA1: 87c2e01a11a276fa04902b42146cc627ab35a52e</em></ul>
+<ul style="font-size: 11px;"><em>SHA256: 278d52be5d8e06301ec52a5f60d6037377e989e94d67c93f4132c6aaf47bec3b</em></ul>
 				</li>
 			</ul>
 		</section>


### PR DESCRIPTION
Introduces Checksumming, including a handy FAQ guide on how to checksum, and what checksumming is.

I don't necessarily agree with everything this site is trying to do, but given that the download servers used by your website aren't backed by HTTPS you should at least be offering checksumming as a way to make sure downloads aren't being modified or tampered with by an outside source who may not have the best intentions towards this project, of which the media industry is likely to be the biggest. This will help keep your users safer than the status quo, and I hope you choose to adopt it consequently.
